### PR TITLE
Fix parsing of `compile_commands.json` commands value

### DIFF
--- a/pythonx/ncm_clang.py
+++ b/pythonx/ncm_clang.py
@@ -11,7 +11,7 @@ def _extract_args_from_cmake(cmd):
     args = None
     if 'command' in cmd:
         # the last arg is filename
-        args = shlex.split(cmd)[:-1]
+        args = shlex.split(cmd['command'])[:-1]
     elif 'arguments' in cmd:
         # the last arg is filename
         args = cmd['arguments'][:-1]


### PR DESCRIPTION
Compiler arguments were not being correctly parsed as the `cmd` dictionary was being passed to `shlex` instead of the `cmd['command']` in `_extract_args_from_cmake(cmd)`.